### PR TITLE
improve "Speed up the regular expression substitution"

### DIFF
--- a/Lib/re/__init__.py
+++ b/Lib/re/__init__.py
@@ -285,7 +285,7 @@ def _compile(pattern, flags):
 @functools.lru_cache(_MAXCACHE)
 def _compile_template(pattern, repl):
     # internal: compile replacement pattern
-    return _sre.template(pattern, _parser.parse_template(repl, pattern))
+    return _sre.template(pattern, *_parser.parse_template(repl, pattern))
 
 # register myself for pickling
 

--- a/Lib/re/_parser.py
+++ b/Lib/re/_parser.py
@@ -989,13 +989,14 @@ def parse_template(source, pattern):
     literal = []
     lappend = literal.append
     def addliteral():
-        if s.istext:
-            result.append(''.join(literal))
-        else:
-            # The tokenizer implicitly decodes bytes objects as latin-1, we must
-            # therefore re-encode the final representation.
-            result.append(''.join(literal).encode('latin-1'))
-        del literal[:]
+        if literal:
+            if s.istext:
+                result.append(''.join(literal))
+            else:
+                # The tokenizer implicitly decodes bytes objects as latin-1, we must
+                # therefore re-encode the final representation.
+                result.append(''.join(literal).encode('latin-1'))
+            del literal[:]
     def addgroup(index, pos):
         if index > pattern.groups:
             raise s.error("invalid group reference %d" % index, pos)
@@ -1061,4 +1062,4 @@ def parse_template(source, pattern):
         else:
             lappend(this)
     addliteral()
-    return result
+    return s.istext, result

--- a/Modules/_sre/clinic/sre.c.h
+++ b/Modules/_sre/clinic/sre.c.h
@@ -626,7 +626,7 @@ exit:
 }
 
 PyDoc_STRVAR(_sre_template__doc__,
-"template($module, pattern, template, /)\n"
+"template($module, pattern, istext, template, /)\n"
 "--\n"
 "\n");
 
@@ -634,25 +634,31 @@ PyDoc_STRVAR(_sre_template__doc__,
     {"template", (PyCFunction)(void(*)(void))_sre_template, METH_FASTCALL, _sre_template__doc__},
 
 static PyObject *
-_sre_template_impl(PyObject *module, PyObject *pattern, PyObject *template);
+_sre_template_impl(PyObject *module, PyObject *pattern, int istext,
+                   PyObject *template);
 
 static PyObject *
 _sre_template(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *pattern;
+    int istext;
     PyObject *template;
 
-    if (!_PyArg_CheckPositional("template", nargs, 2, 2)) {
+    if (!_PyArg_CheckPositional("template", nargs, 3, 3)) {
         goto exit;
     }
     pattern = args[0];
-    if (!PyList_Check(args[1])) {
-        _PyArg_BadArgument("template", "argument 2", "list", args[1]);
+    istext = PyObject_IsTrue(args[1]);
+    if (istext < 0) {
         goto exit;
     }
-    template = args[1];
-    return_value = _sre_template_impl(module, pattern, template);
+    if (!PyList_Check(args[2])) {
+        _PyArg_BadArgument("template", "argument 3", "list", args[2]);
+        goto exit;
+    }
+    template = args[2];
+    return_value = _sre_template_impl(module, pattern, istext, template);
 
 exit:
     return return_value;
@@ -956,4 +962,4 @@ _sre_SRE_Scanner_search(ScannerObject *self, PyTypeObject *cls, PyObject *const 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9454416028280667 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=083b6d2faa5a6d8c input=a9049054013a1b77]*/

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -1061,32 +1061,10 @@ compile_template(_sremodulestate *module_state,
     PyObject *args[] = {(PyObject *)pattern, template};
     PyObject *result = PyObject_Vectorcall(func, args, 2, NULL);
 
-    if (result == NULL && PyErr_ExceptionMatches(PyExc_TypeError)) {
-        /* If the replacement string is unhashable (e.g. bytearray),
-         * convert it to the basic type (str or bytes) and repeat. */
-        if (PyUnicode_Check(template) && !PyUnicode_CheckExact(template)) {
-            PyErr_Clear();
-            template = _PyUnicode_Copy(template);
-        }
-        else if (PyObject_CheckBuffer(template) && !PyBytes_CheckExact(template)) {
-            PyErr_Clear();
-            template = PyBytes_FromObject(template);
-        }
-        else {
-            return NULL;
-        }
-        if (template == NULL) {
-            return NULL;
-        }
-        args[1] = template;
-        result = PyObject_Vectorcall(func, args, 2, NULL);
-        Py_DECREF(template);
-    }
-
     if (result != NULL && Py_TYPE(result) != module_state->Template_Type) {
         PyErr_Format(PyExc_RuntimeError,
-                    "the result of compiling a replacement string is %.200s",
-                    Py_TYPE(result)->tp_name);
+                     "the result of compiling a replacement string is %.200s",
+                     Py_TYPE(result)->tp_name);
         Py_DECREF(result);
         return NULL;
     }

--- a/Modules/_sre/sre.h
+++ b/Modules/_sre/sre.h
@@ -56,12 +56,14 @@ typedef struct {
 
 typedef struct {
     PyObject_VAR_HEAD
-    Py_ssize_t chunks;  /* the number of group references and non-NULL literals
-                         * self->chunks <= 2*Py_SIZE(self) + 1 */
-    PyObject *literal;
+    int is_literal; /* if true, the size is 1 and items[0] is a literal. */
+    int is_text;    /* 1 str, 0 bytes. */
     struct {
-        Py_ssize_t index;
-        PyObject *literal;  /* NULL if empty */
+        enum {TPLT_LITERAL, TPLT_GROUP} type;
+        union {
+            PyObject *literal;
+            Py_ssize_t group;
+        } u;
     } items[0];
 } TemplateObject;
 


### PR DESCRIPTION
The code is concise, easy to understand.
Please review the commits one by one.

I tested with [my benchmark](https://github.com/animalize/re_benchmarks), no change in performance.
This benchmark uses 16 patterns to process (`.sub()`) 100 MiB real text data.
__________
After this, please take over https://github.com/python/cpython/pull/91477,  you can do better and faster  than me.
If implement `re.sub()`/`re.subn()` in C, these C code can be removed:
```c
static PyObject*
import(const char* module, const char* function)
{
    PyObject* name;
    PyObject* mod;
    PyObject* func;

    name = PyUnicode_FromString(module);
    if (!name)
        return NULL;
    mod = PyImport_Import(name);
    Py_DECREF(name);
    if (!mod)
        return NULL;
    func = PyObject_GetAttrString(mod, function);
    Py_DECREF(mod);
    return func;
}
...
    /* delegate to Python code */
    PyObject *func = module_state->compile_template;
    if (func == NULL) {
        func = import("re", "_compile_template");
        if (func == NULL) {
            return NULL;
        }
        Py_XSETREF(module_state->compile_template, func);
    }
```
The Python functions can be registered at the end of `re/__init__.py`
```python
# register Python objects to C code
_sre.register_objects(RegexFlag, _compile, _compile_template)
```
-----------------

Before 3.11 Beta1, I will make a PR for some trivial code polishes.

Then there's nothing to bother you.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
