### PR TITLE
docs: suggested changes to base64 doc backport

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -257,8 +257,9 @@ Refer to the documentation of the individual functions for more information.
    present. While the leading ``<~`` is not required, the input must
    end with ``~>``, or a :exc:`ValueError` is raised.
 
-   *ignorechars* should be a byte string containing characters to ignore
-   from the input. This should only contain whitespace characters, and by
+   *ignorechars* should be a :term:`bytes-like object` containing characters
+   to ignore from the input.
+   This should only contain whitespace characters, and by
    default contains all whitespace characters in ASCII.
 
    .. versionadded:: 3.4
@@ -290,6 +291,11 @@ Refer to the documentation of the individual functions for more information.
 
    Encode the :term:`bytes-like object` *s* using Z85 (as used in ZeroMQ)
    and return the encoded :class:`bytes`.
+
+   The `ZeroMQ specification <https://rfc.zeromq.org/spec/32/>`_
+   requires the length of Z85-encoded data to be a multiple of 5
+   bytes. To produce compliant data frames, you must pad the input
+   data to this function to a multiple of 4 bytes.
 
    .. versionadded:: 3.13
 

--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -257,9 +257,8 @@ Refer to the documentation of the individual functions for more information.
    present. While the leading ``<~`` is not required, the input must
    end with ``~>``, or a :exc:`ValueError` is raised.
 
-   *ignorechars* should be a :term:`bytes-like object` containing characters
-   to ignore from the input.
-   This should only contain whitespace characters, and by
+   *ignorechars* should be a byte string containing characters to ignore
+   from the input. This should only contain whitespace characters, and by
    default contains all whitespace characters in ASCII.
 
    .. versionadded:: 3.4

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -327,9 +327,8 @@ def a85encode(b, *, foldspaces=False, wrapcol=0, pad=False, adobe=False):
     instead of 4 consecutive spaces (ASCII 0x20) as supported by 'btoa'. This
     feature is not supported by the standard encoding used in PDF.
 
-    wrapcol controls whether the output should have newline (b'\\n') characters
-    added to it. If this is non-zero, each output line will be at most this
-    many characters long, excluding the trailing newline.
+    If wrapcol is non-zero, insert a newline (b'\\n') character after at most
+    every wrapcol characters.
 
     pad controls whether zero-padding applied to the end of the input
     is fully retained in the output encoding, as done by btoa,
@@ -377,9 +376,10 @@ def a85decode(b, *, foldspaces=False, adobe=False, ignorechars=b' \t\n\r\v'):
     the leading <~ is not required, the input must end with ~>, or a
     ValueError is raised.
 
-    ignorechars should be a byte string containing characters to ignore from the
-    input. This should only contain whitespace characters, and by default
-    contains all whitespace characters in ASCII.
+    ignorechars should be a bytes-like object containing characters to
+    ignore from the input. This should only contain whitespace
+    characters, and by default contains all whitespace characters in
+    ASCII.
 
     The result is returned as a bytes object.
     """

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -376,10 +376,9 @@ def a85decode(b, *, foldspaces=False, adobe=False, ignorechars=b' \t\n\r\v'):
     the leading <~ is not required, the input must end with ~>, or a
     ValueError is raised.
 
-    ignorechars should be a bytes-like object containing characters to
-    ignore from the input. This should only contain whitespace
-    characters, and by default contains all whitespace characters in
-    ASCII.
+    ignorechars should be a byte string containing characters to ignore from the
+    input. This should only contain whitespace characters, and by default
+    contains all whitespace characters in ASCII.
 
     The result is returned as a bytes object.
     """


### PR DESCRIPTION
A few suggested changes:

1. Use "bytes-like object" consistently
2. Use the shorter description of `wrapcol` from the 3.15 does
3. Add a note about the non-padding of Z85 data which is not compliant